### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/xaas4u/433e78fe-a963-45a5-8f50-5a0baf2a8c2a/1c3e3569-2f53-4685-8659-aadd0db6d60e/_apis/work/boardbadge/5ad7b4c4-036e-4658-9fbf-87b77f2412d3)](https://dev.azure.com/xaas4u/433e78fe-a963-45a5-8f50-5a0baf2a8c2a/_boards/board/t/1c3e3569-2f53-4685-8659-aadd0db6d60e/Microsoft.RequirementCategory)
 # ansible-labs
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Ansible_logo.svg/200px-Ansible_logo.svg.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/xaas4u/433e78fe-a963-45a5-8f50-5a0baf2a8c2a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.